### PR TITLE
:wrench: Gitpod to use the Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build Gitpod Docker image
     runs-on: ubuntu-latest
     environment: a11y-dev
-    if: "github.repository_owner == 'Quansight-Labs' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository_owner == 'jupyter' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     steps:
       - name: Clone repository ⚡
         uses: actions/checkout@v3

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,14 +7,22 @@ tasks:
       echo " 📦 Installing node dependencies "
       yarn install
       npx playwright install
-      cd workspace/accessibility
-      echo "🚀 All ready"
+      echo "🚀 Dependencies installed "
+      cd /workspace/accessibility/
 
 # --------------------------------------------------------
 # exposing ports
 ports:
   - port: 9323
   - port: 8888
+
+# some useful extensions to have
+vscode:
+  extensions:
+    - eamodio.gitlens
+    - ms-python.python
+    - yzhang.markdown-all-in-one
+    - bungcip.better-toml
 
 # --------------------------------------------------------
 # using prebuilds for the container
@@ -36,6 +44,6 @@ github:
     # need to change
     addComment: false
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
-    addBadge: false
+    addBadge: true
     # add a label once the prebuild is ready to pull requests (defaults to false)
     addLabel: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,8 @@ tasks:
       cd testing/jupyterlab
       echo " 📦 Installing node dependencies "
       yarn install
-      cd workspace/a11y
+      npx playwright install
+      cd workspace/accessibility
       echo "🚀 All ready"
 
 # --------------------------------------------------------

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,13 @@
-image:
-  file: testing/tools/gitpod/Dockerfile
+image: quansight/jupyter-a11y:latest
 
 tasks:
   - name: Install JupyterLab Node.js testing dependencies
     init: |
       cd testing/jupyterlab
+      echo " 📦 Installing node dependencies "
       yarn install
       cd workspace/a11y
+      echo "🚀 All ready"
 
 # --------------------------------------------------------
 # exposing ports

--- a/testing/jupyterlab/README.md
+++ b/testing/jupyterlab/README.md
@@ -55,7 +55,7 @@ by modifying the [`playwright.config.ts`](testing/jupyterlab/playwright.config.t
     ```
 
 Your console should output a local URL that you can open in your browser to see
-the test results: typically http://127.0.0.1:9323
+the test results: typically <http://127.0.0.1:9323>
 
 ### :cloud: Running in Gitpod
 

--- a/testing/tools/Dockerfile
+++ b/testing/tools/Dockerfile
@@ -30,7 +30,6 @@ ARG JUPYTER_APP=jupyterlab
 # base HOME for all things in gitpod
 ENV DEBIAN_FRONTEND=noninteractive
 ENV GITPOD_HOME=/home/gitpod \
-    WORKSPACE=/workspace/a11y \
     USER=gitpod \
     GITPOD_GIUD=33333
 


### PR DESCRIPTION
Last step following from #4 - this should make it so that we use the prebuilt image and enables pre-builds for Gitpod